### PR TITLE
Remove EmbeddedChannels from multi-proxy implementation

### DIFF
--- a/src/main/java/me/samxps/crafttunnel/ProxyConfiguration.java
+++ b/src/main/java/me/samxps/crafttunnel/ProxyConfiguration.java
@@ -37,8 +37,6 @@ public class ProxyConfiguration implements Cloneable {
 	}
 	
 	public InetSocketAddress getServerAddress() {
-		if (masterAddress == null)
-			return new InetSocketAddress(serverPort);
 		return new InetSocketAddress(serverHost, serverPort);
 	}
 	

--- a/src/main/java/me/samxps/crafttunnel/ProxyConfiguration.java
+++ b/src/main/java/me/samxps/crafttunnel/ProxyConfiguration.java
@@ -20,6 +20,10 @@ public class ProxyConfiguration implements Cloneable {
 	private String masterAddress = null;
 	private int masterPort = 25881;
 	
+	private boolean HAProxyHeaderEnabled = true;
+	private String serverHost = "localhost";
+	private int serverPort = 25565;
+	
 	public InetSocketAddress getBindAddress() {
 		if (bindHost == null)
 			return new InetSocketAddress(bindPort);
@@ -30,6 +34,12 @@ public class ProxyConfiguration implements Cloneable {
 		if (masterAddress == null)
 			return new InetSocketAddress(masterPort);
 		return new InetSocketAddress(masterAddress, masterPort);
+	}
+	
+	public InetSocketAddress getServerAddress() {
+		if (masterAddress == null)
+			return new InetSocketAddress(serverPort);
+		return new InetSocketAddress(serverHost, serverPort);
 	}
 	
 }

--- a/src/main/java/me/samxps/crafttunnel/netty/HAProxyIdentifier.java
+++ b/src/main/java/me/samxps/crafttunnel/netty/HAProxyIdentifier.java
@@ -10,6 +10,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.AttributeKey;
 import lombok.RequiredArgsConstructor;
 import me.samxps.crafttunnel.netty.channel.ClientChannelHandler;
+import me.samxps.crafttunnel.netty.multi.ProxyEntryPointHandler;
 import me.samxps.crafttunnel.netty.multi.ProxyExitPointHandler;
 
 @RequiredArgsConstructor
@@ -38,7 +39,7 @@ public class HAProxyIdentifier extends ChannelInboundHandlerAdapter {
 	
 	public static HAProxyIdentifier fromClientChannel(Channel clientChannel, String serverHost, int serverPort) {
 		return new HAProxyIdentifier(
-			ClientChannelHandler.getClientAddress(clientChannel), 
+			ProxyEntryPointHandler.getClientAddress(clientChannel), 
 			new InetSocketAddress(serverHost, serverPort)
 		);
 	}

--- a/src/main/java/me/samxps/crafttunnel/netty/InitialHandler.java
+++ b/src/main/java/me/samxps/crafttunnel/netty/InitialHandler.java
@@ -44,14 +44,15 @@ public class InitialHandler extends ChannelInboundHandlerAdapter{
 							return;
 						}
 						
-						ServerConnector connector = getServerConnector();
-						
-						if (connector != null)
+						if (config.getProxyMode() == ProxyMode.MULTI_PROXY_TUNNEL) {
+							if (!ProxyEntryPointHandler.handleClientChannel(ctx.channel()))
+								ctx.close();
+						} else {
 							nextPipeline(
 								ctx, "client", 
-								new ClientChannelHandler(connector)
+								new ClientChannelHandler(DirectServerConnector.newDefault())
 							);
-						else ctx.close();
+						}
 					}
 				}
 				
@@ -95,15 +96,6 @@ public class InitialHandler extends ChannelInboundHandlerAdapter{
 	
 	private void nextPipeline(ChannelHandlerContext ctx, String handlerName, ChannelHandler handler) {
 		ctx.channel().pipeline().addAfter("initial", handlerName, handler);
-	}
-	
-	private ServerConnector getServerConnector() {
-		if (config.getProxyMode() == ProxyMode.PROXY_ONLY) {
-			return DirectServerConnector.newDefault();
-		} else if (config.getProxyMode() == ProxyMode.MULTI_PROXY_TUNNEL) {
-			return ProxyEntryPointHandler.generateConnector();
-		}
-		return null;
 	}
 	
 	@Override

--- a/src/main/java/me/samxps/crafttunnel/netty/InitialHandler.java
+++ b/src/main/java/me/samxps/crafttunnel/netty/InitialHandler.java
@@ -1,5 +1,7 @@
 package me.samxps.crafttunnel.netty;
 
+import java.util.logging.Level;
+
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -23,6 +25,13 @@ public class InitialHandler extends ChannelInboundHandlerAdapter{
 	private final ProxyConfiguration config;
 	private boolean active = true;
 	private ProtocolState state = ProtocolState.HANDSHAKE;
+	
+	@Override
+	public void channelActive(ChannelHandlerContext ctx) throws Exception {
+		CraftTunnel.getLogger().log(Level.INFO, "[{0}] {1} Initial handler connected", new Object[] {
+				"ClientChannelHandler", ProxyEntryPointHandler.getClientAddress(ctx.channel()).toString()
+		});
+	}
 	
 	@Override
 	public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {		

--- a/src/main/java/me/samxps/crafttunnel/netty/channel/ClientChannelHandler.java
+++ b/src/main/java/me/samxps/crafttunnel/netty/channel/ClientChannelHandler.java
@@ -1,6 +1,5 @@
 package me.samxps.crafttunnel.netty.channel;
 
-import java.net.InetSocketAddress;
 import java.util.Queue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.logging.Level;
@@ -10,11 +9,10 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.channel.embedded.EmbeddedChannel;
 import lombok.RequiredArgsConstructor;
 import me.samxps.crafttunnel.CraftTunnel;
 import me.samxps.crafttunnel.netty.connector.ServerConnector;
-import me.samxps.crafttunnel.netty.multi.ProxyExitPointHandler;
+import me.samxps.crafttunnel.netty.multi.ProxyEntryPointHandler;
 
 /**
  * This will handle incoming packets from the connecting player and forward them
@@ -27,17 +25,11 @@ public class ClientChannelHandler extends ChannelInboundHandlerAdapter {
 	private Channel serverChannel;
 	private Queue<Object> queue = new LinkedBlockingQueue<Object>();
 	
-	public static InetSocketAddress getClientAddress(Channel ch) {
-		if (ch instanceof EmbeddedChannel) {
-			return ch.attr(ProxyExitPointHandler.PROXIED_CLIENT_ADDRESS).get();
-		} else return (InetSocketAddress) ch.remoteAddress();
-	}
-	
 	@Override
 	public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
 		
 		CraftTunnel.getLogger().log(Level.INFO, "[{0}] new connection from {1}", new Object[] {
-				"ClientChannelHandler", getClientAddress(ctx.channel()).toString()
+				"ClientChannelHandler", ProxyEntryPointHandler.getClientAddress(ctx.channel()).toString()
 		});
 		
 		// Initiates the connection to the remote server

--- a/src/main/java/me/samxps/crafttunnel/netty/multi/ProxyEntryPointHandler.java
+++ b/src/main/java/me/samxps/crafttunnel/netty/multi/ProxyEntryPointHandler.java
@@ -102,7 +102,7 @@ public class ProxyEntryPointHandler extends ChannelInboundHandlerAdapter {
 		
 		InetSocketAddress clientAddress = getClientAddress(clientChannel);
 		
-		clientChannel.pipeline().addAfter("decoder", "wrapper", new WrapperInboundHandler(
+		clientChannel.pipeline().addAfter("initial", "wrapper", new WrapperInboundHandler(
 				clientAddress, instance.proxyChannel));
 
 		

--- a/src/main/java/me/samxps/crafttunnel/netty/multi/ProxyEntryPointHandler.java
+++ b/src/main/java/me/samxps/crafttunnel/netty/multi/ProxyEntryPointHandler.java
@@ -1,7 +1,6 @@
 package me.samxps.crafttunnel.netty.multi;
 
 import java.net.InetSocketAddress;
-import java.net.ProxySelector;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.logging.Level;
@@ -12,16 +11,9 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.channel.local.LocalChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.util.concurrent.Future;
 import me.samxps.crafttunnel.CraftTunnel;
 import me.samxps.crafttunnel.ServerType;
-import me.samxps.crafttunnel.netty.channel.ClientChannelHandler;
-import me.samxps.crafttunnel.netty.channel.ServerChannelHandler;
-import me.samxps.crafttunnel.netty.connector.ServerConnector;
-import me.samxps.crafttunnel.netty.encode.MinecraftPacketEncoder;
 import me.samxps.crafttunnel.protocol.minecraft.MinecraftPacket;
 import me.samxps.crafttunnel.protocol.multi.WrapperPacket;
 import me.samxps.crafttunnel.protocol.multi.WrapperPacket.WrapperPacketType;
@@ -33,7 +25,7 @@ import me.samxps.crafttunnel.protocol.multi.WrapperPacket.WrapperPacketType;
 public class ProxyEntryPointHandler extends ChannelInboundHandlerAdapter {
 
 	private static HashSet<ProxyEntryPointHandler> instances = new HashSet<ProxyEntryPointHandler>();
-	private HashMap<InetSocketAddress, EmbeddedChannel> virtual = new HashMap<InetSocketAddress, EmbeddedChannel>();
+	private HashMap<InetSocketAddress, Channel> clients = new HashMap<InetSocketAddress, Channel>();
 	
 	private Channel proxyChannel;
 	private EventLoopGroup eventLoop;
@@ -82,52 +74,49 @@ public class ProxyEntryPointHandler extends ChannelInboundHandlerAdapter {
 	}
 	
 	private void handlePacket(WrapperPacket w) {
-		EmbeddedChannel vchannel = virtual.get(w.getClientAddress());
+		Channel clientChannel = clients.get(w.getClientAddress());
 		
-		if (vchannel == null)
+		if (clientChannel == null)
 			 return;
 		
 		if (w.getType() == WrapperPacketType.CONNECTION_CLOSE) {
-			vchannel.close();
+			clientChannel.close();
 		} else if (w.getType() == WrapperPacketType.DATA_BYTES) {
-			vchannel.writeOneInbound(w.getData());
+			clientChannel.write(w.getData());
+			clientChannel.flush();
 		} else if (w.getType() == WrapperPacketType.DATA_PACKET) {
-			vchannel.writeOneInbound(w.getData());
+			clientChannel.write(w.getData());
+			clientChannel.flush();
 		}
 	}
 	
-	private ChannelFuture newVirtualConnection(Channel clientChannel) throws Exception {
-		InetSocketAddress clientAddress = ClientChannelHandler.getClientAddress(clientChannel);
+	public int getScore() {
+		return clients.size();
+	}
+	
+	
+	public static boolean handleClientChannel(Channel clientChannel) {
+		ProxyEntryPointHandler instance = loadBalance();
+		if (instance == null)
+			return false;
 		
-		EmbeddedChannel ch = new EmbeddedChannel(
-				new ServerChannelHandler(clientChannel), 
-				new WrapperOutboundHandler(clientAddress, proxyChannel)
-		);
+		InetSocketAddress clientAddress = getClientAddress(clientChannel);
 		
-		virtual.put(clientAddress, ch);
+		clientChannel.pipeline().addAfter("decoder", "wrapper", new WrapperInboundHandler(
+				clientAddress, instance.proxyChannel));
 
-		ch.closeFuture().addListener(new ChannelFutureListener() {
+		
+		instance.clients.put(clientAddress, clientChannel);
+		
+		clientChannel.closeFuture().addListener(new ChannelFutureListener() {
 			
 			@Override
 			public void operationComplete(ChannelFuture future) throws Exception {
-				virtual.remove(clientAddress);
+				instance.clients.remove(clientAddress);
 			}
 		});
 		
-		proxyChannel.write(
-			new WrapperPacket(
-				clientAddress,
-				WrapperPacketType.CONNECTION_START,
-				null
-			).encode()
-		);
-		proxyChannel.flush();
-		
-		return ch.newSucceededFuture();
-	}
-	
-	public int getScore() {
-		return virtual.size();
+		return true;
 	}
 	
 	/**
@@ -144,38 +133,11 @@ public class ProxyEntryPointHandler extends ChannelInboundHandlerAdapter {
 		
 		return best;
 	}
-	
-	/**
-	 * This will return a new virtual server connector
-	 * to send data trough the multiproxy tunnel
-	 * */
-	public static ServerConnector generateConnector() {
-		ProxyEntryPointHandler handler = loadBalance();
-		if (handler == null) return null;
-		
-		return new ServerConnector() {
-			
-			private Channel ch;
-			
-			@Override
-			public ChannelFuture init(Channel clientChannel) throws Exception {
-				ChannelFuture f = handler.newVirtualConnection(clientChannel);
-				this.ch = f.channel();
-				clientChannel.closeFuture().addListener(new ChannelFutureListener() {
-					
-					@Override
-					public void operationComplete(ChannelFuture future) throws Exception {
-						f.channel().close();
-					}
-				});
-				return f;
-			}
-			
-			@Override
-			public Future<?> exit() throws Exception {
-				return ch.close();
-			}
-		};
+
+	public static InetSocketAddress getClientAddress(Channel clientChannel) {
+		if (clientChannel.remoteAddress() instanceof InetSocketAddress)
+			return (InetSocketAddress) clientChannel.remoteAddress();
+		return null;
 	}
 	
 }

--- a/src/main/java/me/samxps/crafttunnel/netty/multi/WrapperInboundHandler.java
+++ b/src/main/java/me/samxps/crafttunnel/netty/multi/WrapperInboundHandler.java
@@ -1,0 +1,53 @@
+package me.samxps.crafttunnel.netty.multi;
+
+import java.net.InetSocketAddress;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import lombok.RequiredArgsConstructor;
+import me.samxps.crafttunnel.netty.encode.MinecraftPacketEncoder;
+import me.samxps.crafttunnel.protocol.minecraft.MinecraftPacket;
+import me.samxps.crafttunnel.protocol.multi.WrapperPacket;
+import me.samxps.crafttunnel.protocol.multi.WrapperPacket.WrapperPacketType;
+
+@RequiredArgsConstructor
+public class WrapperInboundHandler extends ChannelInboundHandlerAdapter{
+	private final InetSocketAddress clientAddress;
+	private final Channel proxyChannel;
+	
+	@Override
+	public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+		ByteBuf buf;
+		if (msg instanceof ByteBuf) {
+			buf = (ByteBuf) msg;
+		} else if (msg instanceof MinecraftPacket) {
+			buf = ctx.alloc().buffer();
+			MinecraftPacketEncoder.encode((MinecraftPacket) msg, buf);
+		} else {
+			return;
+		}
+		
+		WrapperPacket w = new WrapperPacket(clientAddress, WrapperPacketType.DATA_BYTES, buf);
+		proxyChannel.write(w.encode());
+	}
+	
+	 @Override
+	public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+		proxyChannel.flush();
+		super.channelReadComplete(ctx);
+	}
+	
+	@Override
+	public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+		proxyChannel.write(new WrapperPacket(clientAddress, WrapperPacketType.CONNECTION_CLOSE, null).encode());
+		super.channelInactive(ctx);
+	}
+	
+	@Override
+	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+		cause.printStackTrace();
+		ctx.close();
+	}
+}

--- a/src/main/java/me/samxps/crafttunnel/netty/multi/WrapperInboundHandler.java
+++ b/src/main/java/me/samxps/crafttunnel/netty/multi/WrapperInboundHandler.java
@@ -18,6 +18,18 @@ public class WrapperInboundHandler extends ChannelInboundHandlerAdapter{
 	private final Channel proxyChannel;
 	
 	@Override
+	public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+		proxyChannel.write(
+			new WrapperPacket(
+				clientAddress,
+				WrapperPacketType.CONNECTION_START,
+				null
+			).encode()
+		);
+		proxyChannel.flush();
+	}
+	
+	@Override
 	public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
 		ByteBuf buf;
 		if (msg instanceof ByteBuf) {

--- a/src/main/java/me/samxps/crafttunnel/netty/multi/WrapperInboundHandler.java
+++ b/src/main/java/me/samxps/crafttunnel/netty/multi/WrapperInboundHandler.java
@@ -43,6 +43,7 @@ public class WrapperInboundHandler extends ChannelInboundHandlerAdapter{
 		
 		WrapperPacket w = new WrapperPacket(clientAddress, WrapperPacketType.DATA_BYTES, buf);
 		proxyChannel.write(w.encode());
+		proxyChannel.flush();
 	}
 	
 	 @Override
@@ -54,6 +55,7 @@ public class WrapperInboundHandler extends ChannelInboundHandlerAdapter{
 	@Override
 	public void channelInactive(ChannelHandlerContext ctx) throws Exception {
 		proxyChannel.write(new WrapperPacket(clientAddress, WrapperPacketType.CONNECTION_CLOSE, null).encode());
+		proxyChannel.flush();
 		super.channelInactive(ctx);
 	}
 	


### PR DESCRIPTION
Previously, I thought using EmbeddedChannels as virtual channels was a good idea and that it was really a necessary feature on Entry and Exit handlers. However, creating an WrapperInboundHandler is a better solution and removes a whole layer of complexity on the software.